### PR TITLE
Func utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ func main() {
 		FixtureRootDir: "testdata",
 		FixtureFormat:  mongotest.FixtureFormatJSON,
 		PreInsertFuncs: []mongotest.PreInsertFunc{
+      mongotest.SimpleConvertObjID("users", "_id"),
 			mongotest.SimpleConvertTime("users", "created_at"),
 		},
 	})
@@ -47,6 +48,13 @@ func main() {
 		panic(err)
 	}
 	fmt.Println(n)
+
+  // You can drop the entire database to reset the state to its condition
+  // before applying the fixtures.
+  err = mongotest.DropDatabase()
+  if err != nil {
+    panic(err)
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,39 +22,39 @@ import (
 )
 
 func main() {
-	mongotest.Configure(mongotest.Config{
-		URL:            "mongodb://root:password@127.0.0.1:27017",
-		Database:       "mongotest",
-		FixtureRootDir: "testdata",
-		FixtureFormat:  mongotest.FixtureFormatJSON,
-		PreInsertFuncs: []mongotest.PreInsertFunc{
-      mongotest.SimpleConvertObjID("users", "_id"),
-			mongotest.SimpleConvertTime("users", "created_at"),
-		},
-	})
+        mongotest.Configure(mongotest.Config{
+                URL:            "mongodb://root:password@127.0.0.1:27017",
+                Database:       "mongotest",
+                FixtureRootDir: "testdata",
+                FixtureFormat:  mongotest.FixtureFormatJSON,
+                PreInsertFuncs: []mongotest.PreInsertFunc{
+                        mongotest.SimpleConvertObjID("users", "_id"),
+                        mongotest.SimpleConvertTime("users", "created_at"),
+                },
+        })
 
-	// 1. Read testdata/json/admin_users.json and testdata/json/foo_users.json
-	// 2. Merge read data
-	// 3. Drop collection and insert read data
-	err := mongotest.UseFixture("json/admin_users", "json/foo_users")
-	if err != nil {
-		panic(err)
-	}
+        // 1. Read testdata/json/admin_users.json and testdata/json/foo_users.json
+        // 2. Merge read data
+        // 3. Drop collection and insert read data
+        err := mongotest.UseFixture("json/admin_users", "json/foo_users")
+        if err != nil {
+                panic(err)
+        }
 
-	// Count is helper function.
-	// mongotest has some useful helper functions.
-	n, err := mongotest.Count("users")
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println(n)
+        // Count is a helper function.
+        // mongotest has some useful helper functions.
+        n, err := mongotest.Count("users")
+        if err != nil {
+                panic(err)
+        }
+        fmt.Println(n)
 
-  // You can drop the entire database to reset the state to its condition
-  // before applying the fixtures.
-  err = mongotest.DropDatabase()
-  if err != nil {
-    panic(err)
-  }
+        // You can drop the entire database to reset the state to its condition
+        // before applying the fixtures.
+        err = mongotest.DropDatabase()
+        if err != nil {
+                panic(err)
+        }
 }
 ```
 

--- a/fixture.go
+++ b/fixture.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -59,7 +59,7 @@ func toFilePaths(names ...string) ([]string, error) {
 
 func findFixtureFilePath(name string) (string, error) {
 	dir, base := fixturePath(name)
-	fis, err := ioutil.ReadDir(dir)
+	fis, err := os.ReadDir(dir)
 	if err != nil {
 		return "", err
 	}
@@ -113,7 +113,7 @@ func readFixtureFile(file string) (DataSet, error) {
 	if err != nil {
 		return nil, err
 	}
-	bs, err := ioutil.ReadFile(file)
+	bs, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/mongotest.go
+++ b/mongotest.go
@@ -125,3 +125,30 @@ func SimpleConvertObjID(collectionName, fieldName string) PreInsertFunc {
 		return value, nil
 	}
 }
+
+// DropCollections drops multiple collections with the given names.
+func DropCollections(collections ...string) error {
+	for _, collection := range collections {
+		ctx := context.Background()
+		ctx, coll, cancel, err := connectCollection(ctx, collection)
+		if err != nil {
+			return err
+		}
+		defer cancel()
+		if err := coll.Drop(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DropDatabase drops the entire database.
+func DropDatabase() error {
+	ctx := context.Background()
+	ctx, client, cancel, err := connect(ctx)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	return client.Database(conf.Database).Drop(ctx)
+}

--- a/mongotest.go
+++ b/mongotest.go
@@ -6,6 +6,7 @@ import (
 	"github.com/tkuchiki/parsetime"
 
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 // Try connecting to MongoDB server.
@@ -88,6 +89,38 @@ func SimpleConvertTime(collectionName, fieldName string) PreInsertFunc {
 				return nil, err
 			}
 			value[fieldName] = t
+		}
+		return value, nil
+	}
+}
+
+// SimpleConvertBytes provides simple PreInsertFunc for converting string to BinData
+func SimpleConvertBytes(collectionName, fieldName string) PreInsertFunc {
+	return func(collName string, value DocData) (DocData, error) {
+		if collName == collectionName {
+			sv, ok := value.StringValue(fieldName)
+			if !ok {
+				return value, nil
+			}
+			value[fieldName] = []byte(sv)
+		}
+		return value, nil
+	}
+}
+
+// SimpleConvertObjID provides simple PreInsertFunc for converting string to ObjectID
+func SimpleConvertObjID(collectionName, fieldName string) PreInsertFunc {
+	return func(collName string, value DocData) (DocData, error) {
+		if collName == collectionName {
+			sv, ok := value.StringValue(fieldName)
+			if !ok {
+				return value, nil
+			}
+			objID, err := primitive.ObjectIDFromHex(sv)
+			if err != nil {
+				return nil, err
+			}
+			value[fieldName] = objID
 		}
 		return value, nil
 	}


### PR DESCRIPTION
Hi,

I've been using this package to refactor some store's tests. As I refactor some tests to incorporate this package, I noticed that certain functionalities essential for my use cases were missing, so, I made a few additions:

1. `SimpleConvertObjID`: This function converts a string to a MongoDB ObjectID. It's especially handy when trying to assert equality for an *_id* that's an ObjectID (and not a string). Without this conversion, tests often throw errors.
2. `SimpleConvertBytes`: This converts a string to the *BinData* type. We frequently save data as raw bytes in various use cases.
3. `DropCollections` and `DropDatabase`: These were created to facilitate test cases where each case operates with isolated data. For instance, updating a fixture in one test case shouldn't impact the results of another.

Additionally, I replaced the deprecated `ioutil.ReadDir` call with `os.ReadDir` and updated the README.md.